### PR TITLE
Bug 🐛 Instagram API returns error messages as 200 OK responses

### DIFF
--- a/instagram-api/instagram-api.php
+++ b/instagram-api/instagram-api.php
@@ -3,7 +3,7 @@
 Plugin Name: Instagram Wordpress API
 Plugin URI: http://github.com/msigley/
 Description: Provides functions for accessing the Instagram API. Leverages the Wordpress HTTP API.
-Version: 2.0.1
+Version: 2.0.2
 Author: Matthew Sigley
 License: GPL2
 */

--- a/instagram-api/rest.php
+++ b/instagram-api/rest.php
@@ -66,9 +66,13 @@ class Instagram_WP_API_REST {
 		if( 200 != $response_code && 400 != $response_code )
 			return false;
 		
-		$response_body = wp_remote_retrieve_body( $response );
-		$this->cache_request( $response_body, $endpoint, $method, $body );
-		return json_decode( $response_body );
+		$response_body = wp_remote_retrieve_body($response);
+		$response_body_json = json_decode($response_body);
+		if (isset($response_body_json->error) || !isset($response_body_json->data)) {
+			return false;
+		}
+		$this->cache_request($response_body, $endpoint, $method, $body);
+		return $response_body_json;
 	}
 
 	private function get_cached_request( $endpoint, $method, $body=array() ) {


### PR DESCRIPTION
This PR extends the scenarios where the OAuth response is to be considered an error. I have noticed that the Instagram OAuth could respond with a valid 200 but it contains an error inside. 
If the response data payload is not properly checked to ensure there is a payload, other parts of the application will assume all went well. 

Here is an example payload I got from the Instagram API when my token had expired.
```
{
    "error": {
        "message": "API access deactivated. To reactivate, go to the app dashboard.",
        "type": "OAuthException",
        "code": 200,
        "fbtrace_id": "......"
    }
}
```

When Instagram sends this payload the following piece of code tries to read undefined properties. 
`instagram-api/api.php:21` inside function `instagram_get_user_items`.

Tested on PHP 8.0